### PR TITLE
wip(build): use parallel build for vue2/vue3

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -16,7 +16,11 @@ const pkg = require('../package.json');
 
 const distPath = Path.resolve(__dirname, '..', 'dist');
 
-const configure = ({vueVersion}) => (env = {}, { mode = 'production' }) => {
+const configure = ({name, vueVersion}) => (env = {}, { mode = 'production', configName }) => {
+	if (configName && configName.includes(name)) {
+		return {name}
+	}
+
 	const isProd = mode === 'production';
 
 	// doc: https://github.com/browserslist/browserslist#full-list
@@ -32,6 +36,7 @@ const configure = ({vueVersion}) => (env = {}, { mode = 'production' }) => {
 	console.log('config', { targetsBrowsers, noPresetEnv, noCompress, genSourcemap, vueVersion });
 
 	return {
+		name,
 		entry: [
 			'regenerator-runtime',
 			Path.resolve(__dirname, '../src/index.ts'),
@@ -298,9 +303,9 @@ ${ pkg.name } v${ pkg.version }
 	}
 }
 
-configs = [
-	{vueVersion: "2"},
-	{vueVersion: "3"}
+let configs = [
+	{name: 'vue2', vueVersion: '2' },
+	{name: 'vue3', vueVersion: '3' }
 ]
 
 module.exports = configs.map(configure)

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -16,8 +16,7 @@ const pkg = require('../package.json');
 
 const distPath = Path.resolve(__dirname, '..', 'dist');
 
-module.exports = (env = {}, { mode = 'production' }) => {
-
+const configure = ({vueVersion}) => (env = {}, { mode = 'production' }) => {
 	const isProd = mode === 'production';
 
 	// doc: https://github.com/browserslist/browserslist#full-list
@@ -25,8 +24,7 @@ module.exports = (env = {}, { mode = 'production' }) => {
 	const {
 		targetsBrowsers = 'defaults',
 		noPresetEnv = !isProd,
-		noCompress = !isProd,
-		vueVersion = '3',
+		noCompress = !isProd
 	} = env;
 
 	const genSourcemap = false;
@@ -156,7 +154,7 @@ ${ pkg.name } v${ pkg.version }
 @description ${ pkg.description }.
 @author      ${ pkg.author.name } <${ pkg.author.email }>
 @license     ${ pkg.license }
-			`.trim()),
+		`.trim()),
 		],
 		resolve: {
 			extensions: [".ts", ".js"],
@@ -300,3 +298,9 @@ ${ pkg.name } v${ pkg.version }
 	}
 }
 
+configs = [
+	{vueVersion: "2"},
+	{vueVersion: "3"}
+]
+
+module.exports = configs.map(configure)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "testVue2": "cd test && cross-env VUE_VERSION=2 yarn run start",
     "tests": "jest --runInBand \"tests/.*\\.test.js\"",
     "dev": "webpack --mode=development --config ./build/webpack.config.js --progress --watch",
-    "build": "cross-env-shell webpack --mode=production --config ./build/webpack.config.js --progress --env targetsBrowsers=\\\"$npm_package_browserslist\\\" && cross-env-shell webpack --mode=production --config ./build/webpack.config.js --progress --env vueVersion=\\\"2\\\" --env targetsBrowsers=\\\"$npm_package_browserslist\\\"",
+    "build": "cross-env-shell webpack --mode=production --config ./build/webpack.config.js --progress --env targetsBrowsers=\\\"$npm_package_browserslist\\\"",
     "docs": "cross-env-shell node build/evalHtmlComments.js README.md $npm_package_version && node build/evalHtmlComments.js docs/examples.md $npm_package_version && typedoc --plugin typedoc-plugin-markdown --mode file --tsconfig ./build/tsconfig.json --inputFiles ./src/index.ts --out ./docs/api --readme none --stripInternal --namedAnchors true",
     "pushDocs": "yarn run docs && git add docs/ && cross-env-shell git commit -m \\\"chore(docs): v$npm_package_version API docs & examples \\\" docs",
     "release": "standard-version --header \"\""
@@ -78,6 +78,7 @@
     "puppeteer": "^8.0.0",
     "source-map-explorer": "2.5.2",
     "standard-version": "^9.1.1",
+    "terser-webpack-plugin": "^5.1.1",
     "ts-loader": "^8.0.17",
     "typedoc": "0.19.2",
     "typedoc-plugin-markdown": "3.1.1",


### PR DESCRIPTION
I would be better, but it makes the TerserPlugin fail for some reason at the moment :(

```
ERROR in vue3-sfc-loader.js from Terser
Unexpected token: keyword (var) [vue3-sfc-loader.js:18,16]
    at js_error (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:548:11)
    at croak (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:1272:9)
    at token_error (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:1280:9)
    at unexpected (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:1286:9)
    at expr_atom (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:2523:9)
    at maybe_unary (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:3299:19)
    at expr_ops (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:3350:24)
    at maybe_conditional (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:3355:20)
    at maybe_assign (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:3432:20)
    at expression (/home/toilal/projects/vue-sfc-loader/node_modules/terser/dist/bundle.min.js:3457:24)
```